### PR TITLE
fix: correct STS auth action name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <kafka.version>3.4.0</kafka.version>
         <junit.version>4.12</junit.version>
-        <odps.sdk.version>0.45.0-SNAPSHOT</odps.sdk.version>
+        <odps.sdk.version>0.45.0-public</odps.sdk.version>
         <kafka.connect.storage.common.version>11.1.4</kafka.connect.storage.common.version>
     </properties>
 

--- a/src/main/java/com/aliyun/odps/kafka/connect/account/sts/StsService.java
+++ b/src/main/java/com/aliyun/odps/kafka/connect/account/sts/StsService.java
@@ -27,9 +27,9 @@ public class StsService {
             request.setEndpoint(stsEndpoint);
 
             request.setRoleArn(buildRoleArn(ownId, roleName));
-            request.setActionName("AssumeRoleWithServiceIdentity");
+            request.setActionName("AssumeRole");
             request.putQueryParameter("AssumeRoleFor", ownId);
-            request.setDurationSeconds(12 * 60 * 60L);
+            request.setDurationSeconds(1 * 60 * 60L);
 
             AssumeRoleResponse response = client.getAcsResponse(request);
             String userAk = response.getCredentials().getAccessKeyId();


### PR DESCRIPTION
This PR is to fix STS authentication method when using the connector as reported in https://github.com/aliyun/maxcompute-kafka-connector/issues/2.

cc @frco9