### PR TITLE
fix: correctly fetch STS AK/SK from connector config

### DIFF
--- a/src/main/java/com/aliyun/odps/kafka/connect/account/impl/STSAccountGenerator.java
+++ b/src/main/java/com/aliyun/odps/kafka/connect/account/impl/STSAccountGenerator.java
@@ -14,9 +14,18 @@ public class STSAccountGenerator implements AccountGenerator<StsAccount> {
 
   @Override
   public StsAccount generate(MaxComputeSinkConnectorConfig config) {
-    Map<String, String> env = System.getenv();
-    String ak = env.getOrDefault("ACCESS_ID", "");
-    String sk = env.getOrDefault("ACCESS_KEY", "");
+    String
+        ak =
+        config.getString(MaxComputeSinkConnectorConfig.BaseParameter.ACCESS_ID.getName());
+    String
+        sk =
+        config.getString(MaxComputeSinkConnectorConfig.BaseParameter.ACCESS_KEY.getName());
+    
+    if (ak == null || ak.isEmpty() || sk == null || sk.isEmpty()) {
+      Map<String, String> env = System.getenv();
+      ak = env.getOrDefault("ALIBABA_CLOUD_ACCESS_KEY_ID", "");
+      sk = env.getOrDefault("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "");
+    }
 
     String
         accountId =


### PR DESCRIPTION
Hello!
Just a small PR to correctly fetch AK/SK from connector's config. At the moment, when using STS, AK/SK fetched from `ACCESS_ID` and `ACCESS_KEY` environment variables, not from config. In this PR both way are possible 😊
In this PR i also take the chance fix the environment variable naming convention to `ALIBABA_CLOUD_ACCESS_KEY_ID` and `ALIBABA_CLOUD_ACCESS_KEY_SECRET`.
Thanks in advance!
Cheers 🍻