### PR TITLE
fix: disable `flushStreamPackWithRetry`

### DIFF
--- a/src/main/java/com/aliyun/odps/kafka/connect/MaxComputeSinkWriter.java
+++ b/src/main/java/com/aliyun/odps/kafka/connect/MaxComputeSinkWriter.java
@@ -220,7 +220,6 @@ public class MaxComputeSinkWriter implements Closeable, Callable<Boolean> {
                 .setPartitionSpec(partitionSpec)
                 .setCreatePartition(true)
                 .build();
-        flushStreamPackWithRetry(retryTimes);
         streamPack = recreateRecordPack();
       } catch (TunnelException e) {
         LOGGER.error("Refresh sts token failed: cannot recreate stream session", e);


### PR DESCRIPTION
@dingxin-tech hello! how is it going?

this is my temporary fix i made due to the issue i have reported with your changes https://github.com/aliyun/maxcompute-kafka-connector/issues/5#issuecomment-3229049369.

there is no issue so far with this fix, but i believe this is far from optimal. i will switch to your change once you have bandwidth to make the fix stable 😉